### PR TITLE
Fix up Promise wrap up

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,27 @@
 //Test two exception providers
 //*** Sentry
 var sentry = require('raven')
+var mysql = require('mysql')
+
 var sentryClient = new sentry.Client(process.env.SENTRY_DSN, {
   release: `0.0.0.${process.env.BUILD_VER}`
 })
 
-// much λ, much UX.
-module.exports = function lambda_main(fn) {
-  return function(event, context, callback) {
-    try {
-      var v = fn(event, context, callback)
+var db_connection = mysql.createConnection({
+  host: process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD
+});
 
+// much λ, much UX.
+module.exports = function db_lambda_main(fn) {
+  return function(event, context, callback) {
+    db_connection.connect()
+    try {
       context.callbackWaitsForEmptyEventLoop = true
+
+      var v = fn(event, db_connection, context, callback)
       if (v && typeof v.then == 'function') {
         v.then(val => callback(null, val)).catch(callback)
         return
@@ -22,6 +32,8 @@ module.exports = function lambda_main(fn) {
       console.error(err.stack)
       sentryClient.captureException(err)
       callback(err);
+    } finally {
+      db_connection.end()
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "repository": "https://github.com/BIAINC/exceptional_apex.js",
   "dependencies": {
     "raven": "^0.11.0",
-    "raygun": "^0.8.5"
+    "raygun": "^0.8.5",
+    "mysql": "^2.10.2"
   }
 }


### PR DESCRIPTION
We needed  place to close the DB connection, and .then is the right place to do this vs a finally. Plus, if an exception occurred in a Promise it was not being recorded in Sentry 